### PR TITLE
Add data type exception to percentile_dist

### DIFF
--- a/src/iblphotometry/metrics.py
+++ b/src/iblphotometry/metrics.py
@@ -37,8 +37,10 @@ def percentile_dist(A: nap.Tsd | np.ndarray, pc: tuple = (50, 95), axis=-1) -> f
     """
     if isinstance(A, nap.Tsd):  # "overloading"
         P = np.percentile(z(A.values), pc)
-    if isinstance(A, np.ndarray):
+    elif isinstance(A, np.ndarray):
         P = np.percentile(z(A), pc, axis=axis)
+    else:
+        raise TypeError("A must be nap.Tsd or np.ndarray.")
     return P[1] - P[0]
 
 


### PR DESCRIPTION
- functions should give an error if input data is incorrect type instead of returning None