### PR TITLE
Behavior GUI

### DIFF
--- a/src/iblphotometry/plots.py
+++ b/src/iblphotometry/plots.py
@@ -41,9 +41,6 @@ Loader objects for plotting
 
 
 class PlotSignal:
-    # def __init__(self, *args, **kwargs):
-    #     self.set_data(*args, **kwargs)
-
     def set_data(
         self, raw_signal, times, raw_isosbestic=None, processed_signal=None, fs=None
     ):
@@ -143,7 +140,10 @@ class PlotSignal:
 
 
 class PlotSignalResponse:
-    def __init__(
+    def __init__(self):
+        self.psth_dict = {}
+
+    def set_data(
         self, trials, processed_signal, times, fs=None, event_window=np.array([-1, 2])
     ):
         self.trials = trials
@@ -187,10 +187,20 @@ class PlotSignalResponse:
         except KeyError:
             warnings.warn(f'Event {event} not found in trials table.')
 
-    def plot_trialsort_psth(self):
-        fig, axs = plt.subplots(2, len(self.psth_dict.keys()) - 1)
+    def set_fig_layout(self, figure=None):
+        n = max(1, len(self.psth_dict.keys()) - 1)
+        if figure is None:
+            figure, axs = plt.subplots(2, n, squeeze=False)
+        else:
+            axs = figure.subplots(2, n, squeeze=False)
+        figure.tight_layout()
+        return figure, axs
 
+    def plot_trialsort_psth(self, axs):
         signal_keys = [k for k in self.psth_dict.keys() if k != 'times']
+        if axs.shape[1] < len(signal_keys):
+            raise ValueError("Error, skipping PSTH plotting")
+
         for iaxs, event in enumerate(signal_keys):
             axs_plt = [axs[0, iaxs], axs[1, iaxs]]
             plot_psth(self.psth_dict[event], self.psth_dict['times'], axs=axs_plt)
@@ -206,17 +216,12 @@ class PlotSignalResponse:
             if iaxs > 0:
                 axs[0, iaxs].axis('off')
                 axs[1, iaxs].set_yticks([])
-        fig.tight_layout()
-        return fig, axs
 
-    def plot_processed_trialtick(self, event_key='stimOn_times'):
-        fig, ax = plt.subplots(1, 1)
-        plt.figure(figsize=(10, 6))
+    def plot_processed_trialtick(self, ax, event_key='stimOn_times'):
         events = self.trials[event_key]
         ax.set_ylim([-0.2, 0.1])
         plot_event_tick(events, ax=ax, color='#FFC0CB', ls='-')
         plot_processed_signal(self.processed_signal, self.times, ax=ax)
-        return fig, ax
 
 
 """

--- a/src/iblphotometry_tests/test_plots.py
+++ b/src/iblphotometry_tests/test_plots.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 import pandas as pd
 from pathlib import Path
@@ -7,6 +8,7 @@ import matplotlib.pyplot as plt
 
 from iblphotometry.behavior import psth, psth_times
 import iblphotometry.plots as plots
+from gui.rawdata_visualizer import DataFrameVisualizerApp, BehaviorVisualizerGUI
 from iblphotometry.synthetic import synthetic101
 import iblphotometry.preprocessing as ffpr
 from iblphotometry_tests.base_tests import PhotometryDataTestCase
@@ -95,9 +97,13 @@ class TestPlotters(PhotometryDataTestCase):
         # eid = '77a6741c-81cc-475f-9454-a9b997be02a4'
         # trials = one.load_object(eid, 'trials')
         trials = pd.read_parquet(self.paths['trials_table_kcenia_pqt'])
-        plotobj = plots.PlotSignalResponse(trials, processed_signal, times)
-        plotobj.plot_trialsort_psth()
-        plotobj.plot_processed_trialtick()
+        plotobj = plots.PlotSignalResponse()
+        plotobj.set_data(trials, processed_signal, times)
+        fig, axs = plotobj.set_fig_layout()
+        plotobj.plot_trialsort_psth(fig, axs)
+        fig, ax = plt.subplots(1, 1)
+        plotobj.plot_processed_trialtick(ax)
+        plt.show()
         plt.close('all')
 
     """
@@ -188,9 +194,24 @@ class TestPlotters(PhotometryDataTestCase):
         plots.plot_event_tick(t_events)
         plt.close('all')
 
+    def test_gui(self):
+        df_nph, _, fs = self.get_test_data()
+        processed_signal = df_nph['signal_processed'].values
+        times = df_nph['times'].values
+        trials = pd.read_parquet(self.paths['trials_table_kcenia_pqt'])
+
+        from PyQt5.QtWidgets import QApplication
+        app = QApplication(sys.argv)
+        window = BehaviorVisualizerGUI()
+        window.set_data(processed_signal, times)
+        window.load_trials(trials)
+        window.show()
+        # Uncomment to debug
+        # app.exec_()
+
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()
-    suite.addTest(TestPlotters("test_class_plotsignalresponse"))
+    suite.addTest(TestPlotters("test_gui"))
     runner = unittest.TextTestRunner()
     runner.run(suite)

--- a/src/iblphotometry_tests/test_plots.py
+++ b/src/iblphotometry_tests/test_plots.py
@@ -1,3 +1,4 @@
+import unittest
 import pandas as pd
 from pathlib import Path
 
@@ -186,3 +187,10 @@ class TestPlotters(PhotometryDataTestCase):
         df_nph, t_events, fs = self.get_synthetic_data()
         plots.plot_event_tick(t_events)
         plt.close('all')
+
+
+if __name__ == '__main__':
+    suite = unittest.TestSuite()
+    suite.addTest(TestPlotters("test_class_plotsignalresponse"))
+    runner = unittest.TextTestRunner()
+    runner.run(suite)


### PR DESCRIPTION
Following a request by @GaelleChapuis, I added a minimal GUI that one can open from the raw data visualizer and that displays behavior data.

Existing raw data visualizer, with an additional "Open behavior GUI" button at the top right:

![image](https://github.com/user-attachments/assets/29977a0c-0b39-4ecd-a0b5-4a231653c49e)

Minimal behavior GUI, with a button to select behavior data:

![image](https://github.com/user-attachments/assets/58646866-5311-47cf-9f4b-ab32354adef9)

Action items:

- review and merge 
- verify the data loading logic to ensure the right data variables are passed from the first GUI to the second (filtered data, and times)
