### PR TITLE
Fix qc_signals: band selection, percentile_asymmetry type guard, sliding-window metric kwargs

### DIFF
--- a/src/iblphotometry/metrics.py
+++ b/src/iblphotometry/metrics.py
@@ -90,7 +90,7 @@ def percentile_asymmetry(A: pd.Series | np.ndarray, pc_comp: int = 95, axis=-1) 
         float: the ratio of positive and negative percentile distances
     """
     # TODO embrace pydantic
-    if not (isinstance(A, pd.Series, np.ndarray)):
+    if not (isinstance(A, (pd.Series, np.ndarray))):
         raise TypeError('A must be pd.Series or np.ndarray.')
 
     a = np.absolute(percentile_distance(A, (50, pc_comp), axis=axis))

--- a/src/iblphotometry/qc.py
+++ b/src/iblphotometry/qc.py
@@ -54,10 +54,10 @@ def qc_signals(
             assert signal_band in raw_dfs, f'signal band {signal_band} not present in data'
             signal_bands = [signal_band]
     if brain_region is None:
-        brain_regions = raw_dfs[next(signal_bands)].columns
+        brain_regions = raw_dfs[next(iter(signal_bands))].columns
     else:
         if type(brain_region) is str:
-            assert brain_region in raw_dfs[next(signal_bands)].columns, f'brain region {brain_region} not present in data'
+            assert brain_region in raw_dfs[next(iter(signal_bands))].columns, f'brain region {brain_region} not present in data'
             brain_regions = [brain_region]
 
     # the main qc loop

--- a/src/iblphotometry/qc.py
+++ b/src/iblphotometry/qc.py
@@ -112,7 +112,7 @@ def qc_signals(
                                 'band': band,
                                 'brain_region': _brain_region,
                                 'metric': metric.__name__,
-                                'value': metric(signal_),
+                                'value': metric(signal_, **_metric_kwargs),
                                 'window': w_start + w_len / 2,
                             },
                         )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -41,3 +41,23 @@ class TestMetrics(PhotometryDataTestCase):
         # for event_name in BEHAV_EVENTS:
         #     metrics.ttest_pre_post(raw_tsd, trials, event_name)
         #     metrics.has_responses(raw_tsd, trials, BEHAV_EVENTS)
+
+    def test_percentile_asymmetry_accepts_series_and_array(self):
+        """The type guard admits both accepted types and rejects anything else."""
+        signal = self.signals_dfs['GCaMP']['G0']
+
+        self.assertAlmostEqual(
+            metrics.percentile_asymmetry(signal),
+            metrics.percentile_asymmetry(signal.values),
+        )
+        with self.assertRaises(TypeError):
+            metrics.percentile_asymmetry(list(signal.values))
+
+    def test_percentile_asymmetry_responds_to_pc_comp(self):
+        """Narrowing the compared percentiles moves the ratio."""
+        signal = self.signals_dfs['GCaMP']['G0']
+
+        self.assertNotAlmostEqual(
+            metrics.percentile_asymmetry(signal, pc_comp=95),
+            metrics.percentile_asymmetry(signal, pc_comp=75),
+        )

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from iblphotometry import fpio, metrics, neurophotometrics, qc
+
+from tests.base_tests import PhotometryDataTestCase
+
+
+class TestQCSignals(PhotometryDataTestCase):
+    def setUp(self):
+        super().setUp()
+        path = self.versions_path / 'version_5' / '_neurophotometrics_fpData.raw.pqt'
+        photometry_df = neurophotometrics.from_neurophotometrics_file_to_photometry_df(path)
+        self.signals_dfs = fpio.from_photometry_df(photometry_df)
+
+    def test_runs_over_every_band_and_region_by_default(self):
+        """signal_band=None and brain_region=None means all of both."""
+        qc_result = qc.qc_signals(self.signals_dfs, [metrics.signal_skew])
+
+        self.assertEqual(set(qc_result['band']), set(self.signals_dfs))
+        self.assertEqual(set(qc_result['brain_region']), {'G0', 'G1'})
+
+    def test_restricts_to_the_named_band_and_region(self):
+        qc_result = qc.qc_signals(
+            self.signals_dfs,
+            [metrics.signal_skew],
+            signal_band='GCaMP',
+            brain_region='G0',
+        )
+
+        self.assertEqual(set(qc_result['band']), {'GCaMP'})
+        self.assertEqual(set(qc_result['brain_region']), {'G0'})

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -29,3 +29,39 @@ class TestQCSignals(PhotometryDataTestCase):
 
         self.assertEqual(set(qc_result['band']), {'GCaMP'})
         self.assertEqual(set(qc_result['brain_region']), {'G0'})
+
+    def test_metrics_kwargs_reach_the_sliding_windows(self):
+        """percentile_asymmetry defaults to pc_comp=95, so asking for 75 has to
+        move the per-window values, not only the whole-signal one.
+
+        Flat windows make the denominator zero, so the comparison is restricted
+        to the windows where both runs are finite; np.allclose would pass on the
+        NaNs alone and hide the very thing under test.
+        """
+
+        def run(metrics_kwargs):
+            return qc.qc_signals(
+                self.signals_dfs,
+                [metrics.percentile_asymmetry],
+                metrics_kwargs=metrics_kwargs,
+                signal_band='GCaMP',
+                brain_region='G0',
+                sliding_kwargs={'w_len': 120, 'step_len': 60},
+            )
+
+        default = run({})
+        with_kwargs = run({'percentile_asymmetry': {'pc_comp': 75}})
+        windowed = default['window'].notna()
+
+        # Control: the whole-signal row has always honoured metrics_kwargs, so
+        # this fixture is sensitive to pc_comp.
+        self.assertNotAlmostEqual(
+            default.loc[~windowed, 'value'].iloc[0],
+            with_kwargs.loc[~windowed, 'value'].iloc[0],
+        )
+
+        a = default.loc[windowed, 'value'].values
+        b = with_kwargs.loc[windowed, 'value'].values
+        finite = np.isfinite(a) & np.isfinite(b)
+        self.assertTrue(finite.any(), 'no finite sliding windows were produced')
+        self.assertFalse(np.array_equal(a[finite], b[finite]))


### PR DESCRIPTION
Three fixes to `qc.py` / `metrics.py`, the first two repairing breakage introduced by 1566793 ("ruff induced changes to make the CI pass").

`qc_signals` currently raises `TypeError` on **every** call on `develop` and `main`, so this is a live break rather than an edge case. It had no test, which is why CI stayed green.

### 1. `qc.py:57,60` — band selection

```diff
-        brain_regions = raw_dfs[list(signal_bands)[0]].columns
+        brain_regions = raw_dfs[next(signal_bands)].columns
```

`signal_bands` is `raw_dfs.keys()` when no band is named and a `list` when one is; `next()` accepts neither. Both call sites now use `next(iter(signal_bands))`, which is what the rewrite was reaching for. Affects `qc_eid`, `qc_lots_of_eids` and `tasks.py:776`.

### 2. `metrics.py:93` — `percentile_asymmetry` type guard

```diff
-    if not (isinstance(A, pd.Series) or isinstance(A, np.ndarray)):
+    if not (isinstance(A, pd.Series, np.ndarray)):
```

The tuple was dropped, so the guard raised `TypeError` on every input, including the two types it exists to admit.

### 3. `qc.py:115` — per-metric kwargs in the sliding windows

The whole-signal row already spread `**_metric_kwargs`; the sliding row did not. `metrics_kwargs` was therefore honoured for one and silently dropped for the other, and every windowed `percentile_asymmetry` value was computed at the default `pc_comp=95` regardless of what the caller asked for.

### Tests

New `tests/test_qc.py` (3 tests) and 2 added to `tests/test_metrics.py`, all on the existing `version_5` fixture.

The kwargs test compares only windows finite in both runs: a flat window makes the denominator zero, and `np.allclose` returns `False` on the resulting NaNs alone — a test written that way passes without the fix.

### Suite

`16 passed, 1 failed, 2 skipped`. The failure is `tests/test_plotters.py::TestPlotters::test_plot_psths`, which fails identically on clean `origin/develop` and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mp7x2hkWM6crU8qNu613w6