### PR TITLE
Add target rate and interpolation method options to resample_signal

### DIFF
--- a/src/iblphotometry/processing.py
+++ b/src/iblphotometry/processing.py
@@ -12,6 +12,7 @@ from ibldsp.utils import WindowGenerator
 from scipy.optimize import minimize
 from scipy.stats.distributions import norm
 from scipy.stats import gaussian_kde, t
+from scipy.interpolate import PchipInterpolator
 from scipy.special import pseudo_huber
 
 from inspect import signature
@@ -173,18 +174,55 @@ def resample(signals: dict) -> dict:
     return signals_resampled
 
 
-def resample_signal(signal: pd.DataFrame) -> pd.DataFrame:
+INTERPOLATION_METHODS = {
+    'linear': lambda times, values, times_interp: np.interp(times_interp, times, values),
+    'pchip': lambda times, values, times_interp: PchipInterpolator(times, values)(times_interp),
+}
+
+
+def resample_signal(
+    signal: pd.DataFrame | pd.Series,
+    fs: float | None = None,
+    method: str = 'linear',
+) -> pd.DataFrame | pd.Series:
+    """Resample a signal onto a uniform time grid.
+
+    Parameters
+    ----------
+    signal : pd.DataFrame | pd.Series
+        Time-indexed signal; one column per channel for a DataFrame. Columns are
+        interpolated independently onto the shared grid.
+    fs : float | None
+        Grid rate in Hz. None (the default) keeps the signal's own rate, taken
+        as the median sample spacing, which regularizes a jittered index without
+        changing the sample count appreciably. Pass a rate to put signals from
+        different recordings on a common grid.
+    method : str
+        Interpolation, one of `INTERPOLATION_METHODS`. 'linear' (the default)
+        chords between samples; 'pchip' fits a shape-preserving cubic, which
+        follows curvature without the overshoot a plain cubic spline introduces.
+
+    Returns
+    -------
+    pd.DataFrame | pd.Series
+        The signal on the uniform grid, matching the input's type. The grid runs
+        from the first sample time up to but excluding the last, so it never
+        extrapolates.
+    """
+    if method not in INTERPOLATION_METHODS:
+        raise ValueError(f'method must be one of {sorted(INTERPOLATION_METHODS)}, got {method!r}')
+    interpolate = INTERPOLATION_METHODS[method]
+
     times = signal.index
-    dt = np.median(np.diff(times))
+    dt = np.median(np.diff(times)) if fs is None else 1 / fs
     times_interp = np.arange(times[0], times[-1], dt)
-    signal_interp = {}
     if type(signal) is pd.DataFrame:
-        for col in signal.columns:
-            signal_interp[col] = np.interp(times_interp, times, signal[col])
-        return pd.DataFrame(signal_interp, index=times_interp)
+        return pd.DataFrame(
+            {col: interpolate(times, signal[col], times_interp) for col in signal.columns},
+            index=times_interp,
+        )
     if type(signal) is pd.Series:
-        signal_interp = np.interp(times_interp, times, signal)
-        return pd.Series(signal_interp, index=times_interp)
+        return pd.Series(interpolate(times, signal, times_interp), index=times_interp)
 
 
 """

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -33,6 +33,42 @@ class TestProcessing(PhotometryDataTestCase):
         processing.sliding_z(raw_df, w_len=60, on_error='expand')
         processing.sliding_mad(raw_df, w_len=60)
 
+    def test_resample_signal_defaults_to_the_signals_own_rate(self):
+        """No fs means the median sample spacing, so the rate is preserved."""
+        signal = self.signals_dfs['GCaMP']['G0']
+        resampled = processing.resample_signal(signal)
+
+        dt = np.median(np.diff(signal.index))
+        np.testing.assert_allclose(np.diff(resampled.index), dt)
+
+    def test_resample_signal_honours_an_explicit_rate(self):
+        """fs puts the signal on a 1/fs grid regardless of its own rate."""
+        signal = self.signals_dfs['GCaMP']['G0']
+        resampled = processing.resample_signal(signal, fs=30)
+
+        np.testing.assert_allclose(np.diff(resampled.index), 1 / 30)
+        self.assertGreaterEqual(resampled.index[0], signal.index[0])
+        self.assertLessEqual(resampled.index[-1], signal.index[-1])
+
+    def test_resample_signal_pchip_differs_from_linear_on_a_curve(self):
+        """PCHIP follows curvature; linear chords cut under a convex signal."""
+        times = np.arange(0, 10, 0.1)
+        curved = pd.Series(np.sin(times), index=times)
+
+        linear = processing.resample_signal(curved, fs=7, method='linear')
+        pchip = processing.resample_signal(curved, fs=7, method='pchip')
+
+        np.testing.assert_allclose(linear.index, pchip.index)
+        self.assertFalse(np.allclose(linear.values, pchip.values))
+        # Both track the underlying function; PCHIP does it more closely.
+        truth = np.sin(pchip.index)
+        self.assertLess(np.abs(pchip.values - truth).max(), np.abs(linear.values - truth).max())
+
+    def test_resample_signal_rejects_an_unknown_method(self):
+        signal = self.signals_dfs['GCaMP']['G0']
+        with self.assertRaises(ValueError):
+            processing.resample_signal(signal, method='cubic')
+
 
 class TestRegressionPredict(unittest.TestCase):
     """Predictions must stay matched to the samples they were requested for."""


### PR DESCRIPTION
`resample_signal` could only resample onto the signal's own median sample spacing, with linear interpolation:

```python
def resample_signal(signal: pd.DataFrame) -> pd.DataFrame:
    times = signal.index
    dt = np.median(np.diff(times))
    times_interp = np.arange(times[0], times[-1], dt)
    ...
```

That de-jitters an irregular index but cannot put two recordings on a shared grid. Both existing call sites (`QC_manual_gui.py`, `plotters.plot_raw_data_df`) are single-session, so neither needed one; an analysis comparing sessions does.

### Change

```python
resample_signal(signal, fs=None, method='linear')
```

| argument | default | behaviour |
|---|---|---|
| `fs` | `None` | median sample spacing — unchanged |
| `fs=30` | | uniform 30 Hz grid |
| `method` | `'linear'` | `np.interp` — unchanged |
| `method='pchip'` | | `PchipInterpolator`, shape-preserving cubic |

An unrecognised `method` raises `ValueError` naming the valid set, taken from the `INTERPOLATION_METHODS` dict rather than a second hardcoded list.

The DataFrame and Series branches now share one interpolating callable instead of repeating the `np.interp` call.

### Backwards compatibility

Both defaults reproduce the previous output exactly. Verified against a copy of the old implementation on the `version_5` fixture, for a Series and for a DataFrame — `.equals()` is `True` in both cases. `processing.resample` (the dict wrapper) is untouched and still works.

### Why

PCHIP matters when resampling happens before a z-score rather than after it. Interpolating an already-z-scored signal attenuates its high frequencies, so the result falls short of unit variance by an amount that depends on the recording's noise fraction and how far its native rate sits from the target. Ordering the pipeline as resample → z-score removes that, and both options here are what a resampling pipeline step needs.

### Tests

4 added to `tests/test_processing.py`: default rate preservation, explicit `fs`, PCHIP tracking a sine more closely than linear chords, and the `ValueError`.

Suite: `15 passed, 1 failed, 2 skipped`. The failure is `tests/test_plotters.py::TestPlotters::test_plot_psths`, which fails identically on clean `develop` and is untouched here.

### Not addressed

If `signal` is neither a DataFrame nor a Series the function falls off the end and returns `None` silently. Pre-existing and left alone to keep the diff focused — happy to add a raise if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mp7x2hkWM6crU8qNu613w6